### PR TITLE
[Build] Générer les catalogues swift de ressources Tchap \sans confli…

### DIFF
--- a/TchapX/SupportingFiles/target-development.yml
+++ b/TchapX/SupportingFiles/target-development.yml
@@ -137,7 +137,8 @@ targets:
       script: |
         export PATH="$PATH:/opt/homebrew/bin"
         if which swiftgen >/dev/null; then
-            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml --config Tools/SwiftGen/swiftgen-config-tchap.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config-tchap.yml
         else
             echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
         fi

--- a/TchapX/SupportingFiles/target-production.yml
+++ b/TchapX/SupportingFiles/target-production.yml
@@ -137,7 +137,8 @@ targets:
       script: |
         export PATH="$PATH:/opt/homebrew/bin"
         if which swiftgen >/dev/null; then
-            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml --config Tools/SwiftGen/swiftgen-config-tchap.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config-tchap.yml
         else
             echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
         fi

--- a/TchapX/SupportingFiles/target-staging.yml
+++ b/TchapX/SupportingFiles/target-staging.yml
@@ -137,7 +137,8 @@ targets:
       script: |
         export PATH="$PATH:/opt/homebrew/bin"
         if which swiftgen >/dev/null; then
-            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml --config Tools/SwiftGen/swiftgen-config-tchap.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config.yml
+            swiftgen config run --config Tools/SwiftGen/swiftgen-config-tchap.yml
         else
             echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
         fi

--- a/Tools/SwiftGen/swiftgen-config-tchap.yml
+++ b/Tools/SwiftGen/swiftgen-config-tchap.yml
@@ -8,6 +8,10 @@ xcassets:
     output: TchapAssets.swift
     params:
       enumName: TchapAssets # To not conflict with ElementX/Assets.swift
+      colorTypeName: TchapColor # To not conflict with ElementX/Assets.swift
+      colorAliasName: TchapAssetColorTypeAlias # To not conflict with ElementX/Assets.swift
+      imageTypeName: TchapImage # To not conflict with ElementX/Assets.swift
+      imageAliasName: TchapAssetImageTypeAlias # To not conflict with ElementX/Assets.swift
 strings:
   - inputs: Resources/Localizations/en.lproj
     filter: TchapLocalizable*


### PR DESCRIPTION
Fix #33

La solution est d'utiliser les paramètres supplémentaires de SwiftGen pour différencier les catalogues TchapX de ceux de ElementX : 
- colorTypeName
- colorAliasName
- imageTypeName
- imageAliasName
