### PR TITLE
Activate certificate pinning for *.gouv.fr and not only *.tchap.gouv.fr

### DIFF
--- a/TchapX/production/SupportingFiles/Info.plist
+++ b/TchapX/production/SupportingFiles/Info.plist
@@ -68,7 +68,7 @@
 	<dict>
 		<key>NSPinnedDomains</key>
 		<dict>
-			<key>tchap.gouv.fr</key>
+			<key>gouv.fr</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>


### PR DESCRIPTION
Fix #72 