### PR TITLE
82 update ci for tchapx

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -113,7 +113,7 @@ class UserSessionFlowCoordinatorStateMachine {
         case showRoomDirectorySearchScreen
         /// The room directory search screen has been dismissed.
         // Tchap: add a flag to present the view fullscreen or in sheet.
-//        case dismissedRoomDirectorySearchScreen
+        //        case dismissedRoomDirectorySearchScreen
         case dismissedRoomDirectorySearchScreen(isPresentedInFullScreenMode: Bool)
 
         /// Request presentation of the user profile screen.

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -113,7 +113,7 @@ class UserSessionFlowCoordinatorStateMachine {
         case showRoomDirectorySearchScreen
         /// The room directory search screen has been dismissed.
         // Tchap: add a flag to present the view fullscreen or in sheet.
-        //        case dismissedRoomDirectorySearchScreen
+//        case dismissedRoomDirectorySearchScreen
         case dismissedRoomDirectorySearchScreen(isPresentedInFullScreenMode: Bool)
 
         /// Request presentation of the user profile screen.

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.5 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -51,6 +51,7 @@ extension ClientBuilder {
             builder = builder.proxy(url: httpProxy)
         }
         
+        #if IS_TCHAP_PRODUCTION || IS_TCHAP_STAGING || IS_TCHAP_DEVELOPEMENT
         // Tchap: check certificate pinning if activated.
         if TchapFeatureFlag.Configuration.certificatePinning.isActivated(for: .all) {
             let pemCertificates = InfoPlistReader.app.embeddedPemCertificates
@@ -83,6 +84,8 @@ extension ClientBuilder {
                 }
             }
         }
+        #endif
+        
         return appHooks.clientBuilderHook.configure(builder)
     }
 }

--- a/PreviewTests/Sources/GeneratedPreviewTests.swift
+++ b/PreviewTests/Sources/GeneratedPreviewTests.swift
@@ -1,11 +1,11 @@
-// Generated using Sourcery 2.2.5 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all
 // swiftformat:disable all
 
 import XCTest
-@testable import TchapX_Production // Tchap: adjustement
+@testable import ElementX
 
 extension PreviewTests {
 

--- a/TchapX/SupportingFiles/target-unitTests.yml
+++ b/TchapX/SupportingFiles/target-unitTests.yml
@@ -45,6 +45,8 @@ targets:
         APP_DISPLAY_NAME: TchapX # The name used in the application.
         PRODUCT_NAME: TchapX-UnitTests
         PRODUCT_BUNDLE_IDENTIFIER: ${BASE_BUNDLE_IDENTIFIER}.unit.tests
+        OTHER_SWIFT_FLAGS:
+        - "-DIS_MAIN_APP -DIS_TCHAP_UNIT_TESTS"
       debug:
       release:
 

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
@@ -7,7 +7,11 @@
 
 import XCTest
 
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class TemplateScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AVMetadataMachineReadableCodeObjectExtensionsTest.swift
+++ b/UnitTests/Sources/AVMetadataMachineReadableCodeObjectExtensionsTest.swift
@@ -8,7 +8,13 @@
 import AVKit
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 final class AVMetadataMachineReadableCodeObjectExtensionsTest: XCTestCase {
     func testDecodeQRCodeVersion8() {

--- a/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AnalyticsSettingsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AnalyticsTests.swift
+++ b/UnitTests/Sources/AnalyticsTests.swift
@@ -6,7 +6,14 @@
 //
 
 import AnalyticsEvents
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import PostHog
 import XCTest
 

--- a/UnitTests/Sources/AppLock/AppLockScreenViewModelTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AppLockScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AppLock/AppLockServiceTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockServiceTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AppLockServiceTests: XCTestCase {

--- a/UnitTests/Sources/AppLock/AppLockSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockSettingsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AppLockSetupSettingsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AppLock/AppLockSetupBiometricsScreenViewModelTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockSetupBiometricsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AppLockSetupBiometricsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AppLock/AppLockSetupPINScreenViewModelTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockSetupPINScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class AppLockSetupPINScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/AppLock/AppLockTimerTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockTimerTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class AppLockTimerTests: XCTestCase {
     var timer: AppLockTimer!

--- a/UnitTests/Sources/AppLock/PINTextFieldTests.swift
+++ b/UnitTests/Sources/AppLock/PINTextFieldTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class PINTextFieldTests: XCTestCase {
     func testSanitize() {

--- a/UnitTests/Sources/AppRouteURLParserTests.swift
+++ b/UnitTests/Sources/AppRouteURLParserTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class AppRouteURLParserTests: XCTestCase {
     var appSettings: AppSettings!

--- a/UnitTests/Sources/ArrayTests.swift
+++ b/UnitTests/Sources/ArrayTests.swift
@@ -9,7 +9,13 @@ import Foundation
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class ArrayTests: XCTestCase {
     func testGrouping() {

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 class AttributedStringBuilderTests: XCTestCase {

--- a/UnitTests/Sources/AttributedStringTests.swift
+++ b/UnitTests/Sources/AttributedStringTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 class AttributedStringTests: XCTestCase {

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/AudioRecorderStateTests.swift
+++ b/UnitTests/Sources/AudioRecorderStateTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/AudioRecorderTests.swift
+++ b/UnitTests/Sources/AudioRecorderTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/AuthenticationServiceTests.swift
+++ b/UnitTests/Sources/AuthenticationServiceTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class AuthenticationServiceTests: XCTestCase {
     var client: ClientSDKMock!

--- a/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
+++ b/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class AuthenticationStartScreenViewModelTests: XCTestCase {
     // Nothing to test, the view model has no mutable state.

--- a/UnitTests/Sources/BlockedUsersScreenViewModelTests.swift
+++ b/UnitTests/Sources/BlockedUsersScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class BlockedUsersScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/BugReportScreenViewModelTests.swift
+++ b/UnitTests/Sources/BugReportScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class BugReportScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 import Combine
 import Foundation

--- a/UnitTests/Sources/CallScreenViewModelTests.swift
+++ b/UnitTests/Sources/CallScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class CallScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/ClientProtocolTests.swift
+++ b/UnitTests/Sources/ClientProtocolTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 @testable import MatrixRustSDK
 
 class ClientProtocolTests: XCTestCase {

--- a/UnitTests/Sources/CompletionSuggestionServiceTests.swift
+++ b/UnitTests/Sources/CompletionSuggestionServiceTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 final class CompletionSuggestionServiceTests: XCTestCase {

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 import XCTest
 

--- a/UnitTests/Sources/CreateRoomViewModelTests.swift
+++ b/UnitTests/Sources/CreateRoomViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class CreateRoomScreenViewModelTests: XCTestCase {
@@ -82,7 +88,8 @@ class CreateRoomScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.canCreateRoom)
         
         // When creating the room.
-        clientProxy.createRoomNameTopicIsRoomPrivateIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReturnValue = .success("1")
+        // Tchap: adapted test adding `isEncrypted`
+        clientProxy.createRoomNameTopicIsRoomPrivateIsRoomEncryptedIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReturnValue = .success("1")
         let deferred = deferFulfillment(viewModel.actions) { action in
             guard case .openRoom("1") = action else { return false }
             return true
@@ -91,9 +98,10 @@ class CreateRoomScreenViewModelTests: XCTestCase {
         try await deferred.fulfill()
         
         // Then the room should be created and a topic should not be set.
-        XCTAssertTrue(clientProxy.createRoomNameTopicIsRoomPrivateIsKnockingOnlyUserIDsAvatarURLAliasLocalPartCalled)
-        XCTAssertEqual(clientProxy.createRoomNameTopicIsRoomPrivateIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReceivedArguments?.name, "A")
-        XCTAssertNil(clientProxy.createRoomNameTopicIsRoomPrivateIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReceivedArguments?.topic,
+        // Tchap: adapted test adding `isEncrypted`
+        XCTAssertTrue(clientProxy.createRoomNameTopicIsRoomPrivateIsRoomEncryptedIsKnockingOnlyUserIDsAvatarURLAliasLocalPartCalled)
+        XCTAssertEqual(clientProxy.createRoomNameTopicIsRoomPrivateIsRoomEncryptedIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReceivedArguments?.name, "A")
+        XCTAssertNil(clientProxy.createRoomNameTopicIsRoomPrivateIsRoomEncryptedIsKnockingOnlyUserIDsAvatarURLAliasLocalPartReceivedArguments?.topic,
                      "The topic should be sent as nil when it is empty.")
     }
     

--- a/UnitTests/Sources/DateTests.swift
+++ b/UnitTests/Sources/DateTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 // swiftlint:disable force_unwrapping

--- a/UnitTests/Sources/DeactivateAccountScreenViewModelTests.swift
+++ b/UnitTests/Sources/DeactivateAccountScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class DeactivateAccountScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/DeveloperOptionsScreenViewModelTests.swift
+++ b/UnitTests/Sources/DeveloperOptionsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class DeveloperOptionsScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/EditRoomAddressScreenViewModelTests.swift
+++ b/UnitTests/Sources/EditRoomAddressScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class EditRoomAddressScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/EmojiProviderTests.swift
+++ b/UnitTests/Sources/EmojiProviderTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 final class EmojiProviderTests: XCTestCase {
@@ -88,8 +94,18 @@ final class EmojiProviderTests: XCTestCase {
 }
 
 private class EmojiLoaderMock: EmojiLoaderProtocol {
+    // Tchap: specify target for unit tests
+    #if IS_TCHAP_UNIT_TESTS
+    var categories = [TchapX_Production.EmojiCategory]()
+    func load() async -> [TchapX_Production.EmojiCategory] {
+        categories
+    }
+
+    #else
     var categories = [ElementX.EmojiCategory]()
     func load() async -> [ElementX.EmojiCategory] {
         categories
     }
+
+    #endif
 }

--- a/UnitTests/Sources/ExpiringTaskRunnerTests.swift
+++ b/UnitTests/Sources/ExpiringTaskRunnerTests.swift
@@ -9,7 +9,13 @@ import Foundation
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class ExpiringTaskRunnerTests: XCTestCase {
     enum ExpiringTaskTestError: Error {

--- a/UnitTests/Sources/GeoURITests.swift
+++ b/UnitTests/Sources/GeoURITests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 final class GeoURITests: XCTestCase {

--- a/UnitTests/Sources/GlobalSearchScreenViewModelTests.swift
+++ b/UnitTests/Sources/GlobalSearchScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class GlobalSearchScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/HomeScreenRoomTests.swift
+++ b/UnitTests/Sources/HomeScreenRoomTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class HomeScreenRoomTests: XCTestCase {

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class HomeScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class InviteUsersScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class JoinRoomScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/KeychainControllerTests.swift
+++ b/UnitTests/Sources/KeychainControllerTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 class KeychainControllerTests: XCTestCase {

--- a/UnitTests/Sources/KnockRequestsListScreenViewModelTests.swift
+++ b/UnitTests/Sources/KnockRequestsListScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class KnockRequestsListScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/LayoutTests/CollapsibleFlowLayoutTests.swift
+++ b/UnitTests/Sources/LayoutTests/CollapsibleFlowLayoutTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import SwiftUI
 import XCTest
 

--- a/UnitTests/Sources/LayoutTests/LayoutMocks.swift
+++ b/UnitTests/Sources/LayoutTests/LayoutMocks.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import SwiftUI
 

--- a/UnitTests/Sources/LegalInformationScreenViewModelTests.swift
+++ b/UnitTests/Sources/LegalInformationScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class LegalInformationScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/LocalizationTests.swift
+++ b/UnitTests/Sources/LocalizationTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 class LocalizationTests: XCTestCase {

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 @testable import MatrixRustSDK
 import XCTest
 

--- a/UnitTests/Sources/LoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/LoginScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class LoginScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/MapTilerURLBuildersTests.swift
+++ b/UnitTests/Sources/MapTilerURLBuildersTests.swift
@@ -6,7 +6,14 @@
 //
 
 import CoreLocation
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 final class MapTilerURLBuildersTests: XCTestCase {

--- a/UnitTests/Sources/MatrixEntityRegexTests.swift
+++ b/UnitTests/Sources/MatrixEntityRegexTests.swift
@@ -9,7 +9,13 @@ import Foundation
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class MatrixEntityRegexTests: XCTestCase {
     func testHomeserver() {

--- a/UnitTests/Sources/MediaPlayerProviderTests.swift
+++ b/UnitTests/Sources/MediaPlayerProviderTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 import XCTest
 

--- a/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 import Combine
 import Kingfisher

--- a/UnitTests/Sources/MediaProvider/MockImageCache.swift
+++ b/UnitTests/Sources/MediaProvider/MockImageCache.swift
@@ -4,7 +4,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 //
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 @testable import Kingfisher
 import UIKit
 

--- a/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
+++ b/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class MediaUploadPreviewScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/MediaUploadingPreprocessorTests.swift
+++ b/UnitTests/Sources/MediaUploadingPreprocessorTests.swift
@@ -8,7 +8,13 @@
 import UniformTypeIdentifiers
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 final class MediaUploadingPreprocessorTests: XCTestCase {
     var appSettings: AppSettings!

--- a/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
+++ b/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class MessageForwardingScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/NavigationRootCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationRootCoordinatorTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NavigationRootCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NavigationSplitCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/NavigationStackCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationStackCoordinatorTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NavigationStackCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
+++ b/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
@@ -9,7 +9,13 @@ import Combine
 import NotificationCenter
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 final class NotificationManagerTests: XCTestCase {
@@ -243,7 +249,14 @@ extension NotificationManagerTests: NotificationManagerDelegate {
         notificationTappedDelegateCalled = true
     }
     
+    // Tchap: specify target for unit tests
+    #if IS_TCHAP_UNIT_TESTS
+    func handleInlineReply(_ service: TchapX_Production.NotificationManagerProtocol, content: UNNotificationContent, replyText: String) async {
+        handleInlineReplyDelegateCalled = true
+    }
+    #else
     func handleInlineReply(_ service: ElementX.NotificationManagerProtocol, content: UNNotificationContent, replyText: String) async {
         handleInlineReplyDelegateCalled = true
     }
+    #endif
 }

--- a/UnitTests/Sources/NotificationSettingsEditScreenViewModelTests.swift
+++ b/UnitTests/Sources/NotificationSettingsEditScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NotificationSettingsEditScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NotificationSettingsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/PermalinkTests.swift
+++ b/UnitTests/Sources/PermalinkTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 import XCTest
 

--- a/UnitTests/Sources/PillContextTests.swift
+++ b/UnitTests/Sources/PillContextTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class PillContextTests: XCTestCase {

--- a/UnitTests/Sources/PinnedEventsBannerStateTests.swift
+++ b/UnitTests/Sources/PinnedEventsBannerStateTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class PinnedEventsBannerStateTests: XCTestCase {
     func testEmpty() {

--- a/UnitTests/Sources/PollFormScreenViewModelTests.swift
+++ b/UnitTests/Sources/PollFormScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class PollFormScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
@@ -10,7 +10,13 @@ import XCTest
 
 import MatrixRustSDK
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 final class QRCodeLoginScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/ReportContentViewModelTests.swift
+++ b/UnitTests/Sources/ReportContentViewModelTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 @MainActor

--- a/UnitTests/Sources/ResolveVerifiedUserSendFailureScreenViewModelTests.swift
+++ b/UnitTests/Sources/ResolveVerifiedUserSendFailureScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class ResolveVerifiedUserSendFailureScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RestorationTokenTests.swift
+++ b/UnitTests/Sources/RestorationTokenTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 
 class RestorationTokenTests: XCTestCase {

--- a/UnitTests/Sources/RoomChangePermissionsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomChangePermissionsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomChangePermissionsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomChangeRolesScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomChangeRolesScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomChangeRolesScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomDetailsEditScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsViewModelTests.swift
@@ -10,7 +10,13 @@ import MatrixRustSDK
 import SwiftUI
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomDetailsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomDirectorySearchScreenScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDirectorySearchScreenScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomDirectorySearchScreenScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/RoomFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/RoomFlowCoordinatorTests.swift
@@ -8,7 +8,14 @@
 import XCTest
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomFlowCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/RoomListFiltersStateTests.swift
+++ b/UnitTests/Sources/RoomListFiltersStateTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 final class RoomListFiltersStateTests: XCTestCase {
     var state: RoomListFiltersState!

--- a/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomMemberDetailsViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomMembersListScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomMembersListScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomMembersListScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
@@ -9,7 +9,13 @@ import Combine
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomNotificationSettingsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomPermissionsTests.swift
+++ b/UnitTests/Sources/RoomPermissionsTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class RoomPermissionsTests: XCTestCase {
     func testFromRust() {

--- a/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomPollsHistoryScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomRolesAndPermissionsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomRolesAndPermissionsScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class RoomRolesAndPermissionsScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 
 import Combine

--- a/UnitTests/Sources/RoomStateEventStringBuilderTests.swift
+++ b/UnitTests/Sources/RoomStateEventStringBuilderTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 import XCTest
 

--- a/UnitTests/Sources/RoomSummaryTests.swift
+++ b/UnitTests/Sources/RoomSummaryTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class RoomSummaryTests: XCTestCase {
     // swiftlint:disable:next large_tuple

--- a/UnitTests/Sources/SecureBackupKeyBackupScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecureBackupKeyBackupScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SecureBackupKeyBackupScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/SecureBackupLogoutConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecureBackupLogoutConfirmationScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SecureBackupLogoutConfirmationScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/SecureBackupRecoveryKeyScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecureBackupRecoveryKeyScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SecureBackupRecoveryKeyScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/SecureBackupScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecureBackupScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SecureBackupScreenViewModelTests: XCTestCase { }

--- a/UnitTests/Sources/SecurityAndPrivacyScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecurityAndPrivacyScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SecurityAndPrivacyScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/ServerConfigurationScreenViewStateTests.swift
+++ b/UnitTests/Sources/ServerConfigurationScreenViewStateTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class ServerConfirmationScreenViewStateTests: XCTestCase {

--- a/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class ServerConfirmationScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class ServerSelectionScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/SessionDirectoriesTests.swift
+++ b/UnitTests/Sources/SessionDirectoriesTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class SessionDirectoriesTests: XCTestCase {
     let fileManager = FileManager.default

--- a/UnitTests/Sources/SessionVerificationStateMachineTests.swift
+++ b/UnitTests/Sources/SessionVerificationStateMachineTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SessionVerificationStateMachineTests: XCTestCase {

--- a/UnitTests/Sources/SessionVerificationViewModelTests.swift
+++ b/UnitTests/Sources/SessionVerificationViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SessionVerificationViewModelTests: XCTestCase {

--- a/UnitTests/Sources/SettingsViewModelTests.swift
+++ b/UnitTests/Sources/SettingsViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SettingsScreenViewModelTests: XCTestCase {
@@ -19,7 +25,12 @@ class SettingsScreenViewModelTests: XCTestCase {
     @MainActor override func setUpWithError() throws {
         cancellables.removeAll()
         let userSession = UserSessionMock(.init(clientProxy: ClientProxyMock(.init(userID: ""))))
+        // Tchap: specify target for unit tests
+        #if IS_TCHAP_UNIT_TESTS
+        viewModel = SettingsScreenViewModel(userSession: userSession, appSettings: AppSettings())
+        #else
         viewModel = SettingsScreenViewModel(userSession: userSession)
+        #endif
         context = viewModel.context
     }
 

--- a/UnitTests/Sources/SoftLogoutViewModelTests.swift
+++ b/UnitTests/Sources/SoftLogoutViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class SoftLogoutViewModelTests: XCTestCase {
     let credentials = SoftLogoutScreenCredentials(userID: "mock_user_id",

--- a/UnitTests/Sources/StartChatViewModelTests.swift
+++ b/UnitTests/Sources/StartChatViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class StartChatScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/StaticLocationScreenViewModelTests.swift
+++ b/UnitTests/Sources/StaticLocationScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class StaticLocationScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/StringTests.swift
+++ b/UnitTests/Sources/StringTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class StringTests: XCTestCase {
     func testEmptyIsAscii() {

--- a/UnitTests/Sources/TextBasedRoomTimelineTests.swift
+++ b/UnitTests/Sources/TextBasedRoomTimelineTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 final class TextBasedRoomTimelineTests: XCTestCase {

--- a/UnitTests/Sources/TimelineItemFactoryTests.swift
+++ b/UnitTests/Sources/TimelineItemFactoryTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import MatrixRustSDK
 
 import XCTest

--- a/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import QuickLook
 import XCTest
 

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 import Combine
 import MatrixRustSDK

--- a/UnitTests/Sources/TimelineViewModelTests.swift
+++ b/UnitTests/Sources/TimelineViewModelTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 import Combine
 import MatrixRustSDK

--- a/UnitTests/Sources/URLComponentsTests.swift
+++ b/UnitTests/Sources/URLComponentsTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class URLComponentsTests: XCTestCase {
     func testAddFragmentQueryItems() {

--- a/UnitTests/Sources/UserAgentBuilderTests.swift
+++ b/UnitTests/Sources/UserAgentBuilderTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class UserAgentBuilderTests: XCTestCase {
     func testIsNotNil() {

--- a/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
+++ b/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class UserDiscoveryServiceTest: XCTestCase {

--- a/UnitTests/Sources/UserIndicatorControllerTests.swift
+++ b/UnitTests/Sources/UserIndicatorControllerTests.swift
@@ -9,7 +9,13 @@ import Foundation
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class UserIndicatorControllerTests: XCTestCase {

--- a/UnitTests/Sources/UserPreferenceTests.swift
+++ b/UnitTests/Sources/UserPreferenceTests.swift
@@ -5,7 +5,13 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/UserProfileScreenViewModelTests.swift
+++ b/UnitTests/Sources/UserProfileScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class UserProfileScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/UserSession/UserSessionTests.swift
+++ b/UnitTests/Sources/UserSession/UserSessionTests.swift
@@ -5,7 +5,14 @@
 // Please see LICENSE files in the repository root for full details.
 //
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import XCTest
 
 final class UserSessionTests: XCTestCase { }

--- a/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
@@ -8,7 +8,14 @@
 import XCTest
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class UserSessionFlowCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/VoiceMessageCacheTests.swift
+++ b/UnitTests/Sources/VoiceMessageCacheTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/VoiceMessageMediaManagerTests.swift
+++ b/UnitTests/Sources/VoiceMessageMediaManagerTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/UnitTests/Sources/VoiceMessageRecorderTests.swift
+++ b/UnitTests/Sources/VoiceMessageRecorderTests.swift
@@ -6,7 +6,14 @@
 //
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 import Foundation
 import XCTest
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,6 +199,7 @@ lane :config_nightly do |options|
   end
 end
 
+# Tchap: Disable upload to Sentry for the moment,
 # $sentry_retry=0
 lane :upload_dsyms_to_sentry do |options|
 #   auth_token = ENV["SENTRY_AUTH_TOKEN"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -160,7 +160,7 @@ end
 
 lane :config_production do
   config_secrets()
-  xcodegen(spec: "project.yml")
+  xcodegen(spec: "project-tchap-x.yml")
 end
 
 lane :config_nightly do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,11 @@ end
 lane :unit_tests do |options|
   reset_simulator = ENV.key?('CI')
   
+  # Tchap: generate xcode project because .xcodeporj files are not gitted.
+  xcodegen(
+    spec: "project-tchap-x.yml"
+  )
+  
   run_tests(
     project: "TchapX.xcodeproj",
     scheme: "TchapX-UnitTests",
@@ -169,7 +174,7 @@ lane :config_nightly do |options|
   build_number = options[:build_number]
   UI.user_error!("Invalid build number.") unless !build_number.to_s.empty?
 
-  target_file_path = "../project.yml"
+  target_file_path = "../project-tchap-x.yml"
   data = YAML.load_file target_file_path
   
   # Check if the "path" already exists in the "include" array
@@ -181,7 +186,7 @@ lane :config_nightly do |options|
   
   File.open(target_file_path, 'w') { |f| YAML.dump(data, f) }
 
-  xcodegen(spec: "project.yml")
+  xcodegen(spec: "project-tchap-x.yml")
 
   # Automatically done by Xcode Cloud. Cannot override
   # https://developer.apple.com/documentation/xcode/setting-the-next-build-number-for-xcode-cloud-builds
@@ -253,7 +258,7 @@ lane :release_to_github do
 end
 
 lane :prepare_next_release do
-  target_file_path = "../project.yml"
+  target_file_path = "../project-tchap-x.yml"
   xcode_project_file_path = "../TchapX.xcodeproj"
 
   data = YAML.load_file target_file_path
@@ -273,7 +278,7 @@ lane :prepare_next_release do
   sh("sed -i '' 's/MARKETING_VERSION: #{current_version}/MARKETING_VERSION: #{new_version}/g' #{target_file_path}")
   UI.message("Version updated from #{current_version} to #{new_version}")
 
-  xcodegen(spec: "project.yml")
+  xcodegen(spec: "project-tchap-x.yml")
 
   setup_git()
 
@@ -288,7 +293,7 @@ lane :tag_nightly do |options|
   build_number = options[:build_number]
   UI.user_error!("Invalid build number.") unless !build_number.to_s.empty?
 
-  xcodegen_project_file_path = "../project.yml"
+  xcodegen_project_file_path = "../project-tchap-x.yml"
   data = YAML.load_file xcodegen_project_file_path
   current_version = data["settings"]["MARKETING_VERSION"]
 
@@ -325,7 +330,7 @@ private_lane :git_push do |options|
 end
 
 lane :config_alpha do
-  target_file_path = "../project.yml"
+  target_file_path = "../project-tchap-x.yml"
   data = YAML.load_file target_file_path
   
   # Check if the "path" already exists in the "include" array
@@ -335,7 +340,7 @@ lane :config_alpha do
   
   File.open(target_file_path, 'w') { |f| YAML.dump(data, f) }
 
-  xcodegen(spec: "project.yml")
+  xcodegen(spec: "project-tchap-x.yml")
 
   version = ENV["GITHUB_PR_NUMBER"]
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,6 +82,7 @@ lane :unit_tests do |options|
   reset_simulator = ENV.key?('CI')
   
   run_tests(
+    project: "TchapX.xcodeproj",
     scheme: "TchapX-UnitTests",
     device: "iPhone 16 (18.1)",
     ensure_devices_found: true,
@@ -92,6 +93,7 @@ lane :unit_tests do |options|
   
   if !options[:skip_previews]
     run_tests(
+      project: TchapX.xcodeproj,
       scheme: "PreviewTests",
       device: "iPhone SE (3rd generation) (18.1)",
       ensure_devices_found: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ if File.exist?(enterprise)
 end
 
 before_all do
-  xcversion(version: "16.1")
+  xcversion(version: "16.2")
 
   ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "180"
   ENV["FASTLANE_XCODE_LIST_TIMEOUT"] = "180"
@@ -22,16 +22,16 @@ lane :build_alpha do
 
   config_alpha()
 
-  code_signing_identity = "Apple Distribution: Vector Creations Limited (7J4U792NQT)"
+  code_signing_identity = "Apple Distribution: DINSIC (NVMQD635C6)"
   
-  app_provisioning_profile_name = "ElementX PR Ad Hoc"
-  app_bundle_identifier = "io.element.elementx.pr"
+  app_provisioning_profile_name = "TchapX Ad Hoc"
+  app_bundle_identifier = "fr.gouv.tchapx"
 
-  nse_provisioning_profile_name = "ElementX NSE PR Ad Hoc"
-  nse_bundle_identifier = "io.element.elementx.pr.nse"
+  nse_provisioning_profile_name = "TchapX NSE PR Ad Hoc"
+  nse_bundle_identifier = "fr.gouv.tchapx.nse"
 
   update_code_signing_settings(
-    targets: ["ElementX"],
+    targets: ["TchapX-Production"],
     use_automatic_signing: false,
     bundle_identifier: app_bundle_identifier,
     profile_name: app_provisioning_profile_name,
@@ -46,7 +46,7 @@ lane :build_alpha do
   )
 
   update_code_signing_settings(
-    targets: ["NSE"],
+    targets: ["TchapX-Production-NSE"],
     use_automatic_signing: false,
     bundle_identifier: nse_bundle_identifier,
     profile_name: nse_provisioning_profile_name,
@@ -61,7 +61,7 @@ lane :build_alpha do
   )
 
   build_ios_app(
-    scheme: "ElementX",
+    scheme: "TchapX-Production",
     clean: true,
     export_method: "ad-hoc",
     output_directory: "build",
@@ -185,49 +185,49 @@ lane :config_nightly do |options|
   # https://developer.apple.com/documentation/xcode/setting-the-next-build-number-for-xcode-cloud-builds
   # bump_build_number()
 
-  release_version = get_version_number(target: "ElementX")
+  release_version = get_version_number(target: "TchapX-Production")
 
   Dir.chdir ".." do
     sh("swift run tools app-icon-banner Variants/Nightly/Resources/Nightly.xcassets/NightlyAppIcon.appiconset/AppIcon.png --banner-text '#{release_version} (#{build_number})'")
   end
 end
 
-$sentry_retry=0
+# $sentry_retry=0
 lane :upload_dsyms_to_sentry do |options|
-  auth_token = ENV["SENTRY_AUTH_TOKEN"]
-  UI.user_error!("Invalid Sentry Auth token.") unless !auth_token.to_s.empty?
-
-  dsym_path = options[:dsym_path]
-  UI.user_error!("Invalid DSYM path.") unless !dsym_path.to_s.empty?
-
-  begin
-    sentry_upload_dif(
-      auth_token: auth_token,
-      org_slug: 'element',
-      project_slug: 'element-x-ios',
-      url: 'https://sentry.tools.element.io/',
-      path: dsym_path,
-    )
-  rescue => exception
-    $sentry_retry += 1
-
-    if $sentry_retry <= 5
-      UI.message "Sentry failed, retrying."
-      upload_dsyms_to_sentry options
-    else
-      raise exception
-    end
-  end
+#   auth_token = ENV["SENTRY_AUTH_TOKEN"]
+#   UI.user_error!("Invalid Sentry Auth token.") unless !auth_token.to_s.empty?
+# 
+#   dsym_path = options[:dsym_path]
+#   UI.user_error!("Invalid DSYM path.") unless !dsym_path.to_s.empty?
+# 
+#   begin
+#     sentry_upload_dif(
+#       auth_token: auth_token,
+#       org_slug: 'element',
+#       project_slug: 'element-x-ios',
+#       url: 'https://sentry.tools.element.io/',
+#       path: dsym_path,
+#     )
+#   rescue => exception
+#     $sentry_retry += 1
+# 
+#     if $sentry_retry <= 5
+#       UI.message "Sentry failed, retrying."
+#       upload_dsyms_to_sentry options
+#     else
+#       raise exception
+#     end
+#   end
 end
 
 lane :release_to_github do
   api_token = ENV["GITHUB_TOKEN"]
   UI.user_error!("Invalid GitHub API token.") unless !api_token.to_s.empty?
 
-  release_version = get_version_number(target: "ElementX")
+  release_version = get_version_number(target: "TchapX")
 
   github_release = set_github_release(
-    repository_name: "element-hq/element-x-ios",
+    repository_name: "tchapgouv/tchap-x-ios",
     api_token: api_token,
     name: release_version,
     tag_name: release_version,
@@ -252,7 +252,7 @@ end
 
 lane :prepare_next_release do
   target_file_path = "../project.yml"
-  xcode_project_file_path = "../ElementX.xcodeproj"
+  xcode_project_file_path = "../TchapX.xcodeproj"
 
   data = YAML.load_file target_file_path
   current_version = data["settings"]["MARKETING_VERSION"]
@@ -299,8 +299,8 @@ lane :tag_nightly do |options|
 end
 
 private_lane :setup_git do
-  sh("git config --global user.name 'Element CI'")
-  sh("git config --global user.email 'ci@element.io'")
+#   sh("git config --global user.name 'Element CI'")
+#   sh("git config --global user.email 'ci@element.io'")
 end
 
 private_lane :git_push do |options|
@@ -379,7 +379,7 @@ private_lane :upload_to_browserstack do
     browserstack_username: browserstack_username,
     browserstack_access_key: browserstack_access_key,
     file_path: lane_context[SharedValues::IPA_OUTPUT_PATH],
-    custom_id: "element-x-ios-pr"
+    custom_id: "tchap-x-ios-pr"
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,7 +82,7 @@ lane :unit_tests do |options|
   reset_simulator = ENV.key?('CI')
   
   run_tests(
-    scheme: "UnitTests",
+    scheme: "TchapX-UnitTests",
     device: "iPhone 16 (18.1)",
     ensure_devices_found: true,
     result_bundle: true,


### PR DESCRIPTION
Fix #82 

- [x] Set TchapX developer and project parameters into fastlane settings
- [x] generate TchapX.xcodeproj via xcodegen before running unit tests
- [x] Target TchapX Xcode project rather than ElementX Xcode project
- [x] Target TchapX-UnitTests rather than UnitTests target
- [x] add TchapX.xcodeproj as `project` parameter to run_tests lane
- [x] add 'IS_TCHAP_UNIT_TESTS' symbol to adapt unit tests target import
- [x] adapt unit tests target imports
