### PR TITLE
BugReport.reportUrl is now optional. Fix Unit Test.

### DIFF
--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -43,7 +43,9 @@ class BugReportServiceTests: XCTestCase {
                                   files: [])
         let progressSubject = CurrentValueSubject<Double, Never>(0.0)
         let response = try await bugReportService.submitBugReport(bugReport, progressListener: progressSubject).get()
-        XCTAssertFalse(response.reportUrl.isEmpty)
+        // Tchap: BugReport.reportUrl is now optional.
+//        XCTAssertFalse(response.reportUrl.isEmpty)
+        XCTAssertFalse(response.reportUrl?.isEmpty ?? true)
     }
     
     func testInitialStateWithRealService() throws {


### PR DESCRIPTION
Fix #128 