### PR TITLE
Gérer la fonte custom Tchap dans la NavBar à l'installation du dégradé

### DIFF
--- a/ElementX/Sources/Application/AppDelegate.swift
+++ b/ElementX/Sources/Application/AppDelegate.swift
@@ -32,7 +32,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         CompoundDesignTokensResources.registerFonts()
         
         // Tchap: set appearance from Compound Design Tokens
-        CompoundDesignTokensResources.setAppearance()
+        CompoundDesignTokensResources.setNavigationBarAppearance()
         
         return true
     }

--- a/ElementX/Sources/Screens/HomeScreen/View/BloomModifier.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/BloomModifier.swift
@@ -19,9 +19,12 @@ extension View {
 private struct BloomModifier: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     
-    @State private var standardAppearance = UINavigationBarAppearance()
-    @State private var scrollEdgeAppearance = UINavigationBarAppearance()
-    
+    // Tchap: add title's font customization.
+//    @State private var standardAppearance = UINavigationBarAppearance()
+//    @State private var scrollEdgeAppearance = UINavigationBarAppearance()
+    @State private var standardAppearance = UINavigationBarAppearance().withTchapFonts()
+    @State private var scrollEdgeAppearance = UINavigationBarAppearance().withTchapFonts()
+
     @State private var bloom = Bloom()
     
     func body(content: Content) -> some View {


### PR DESCRIPTION
Fix #175 

En relation avec https://github.com/tchapgouv/compound-design-tokens/pull/11