### PR TITLE
Fix some CI Unit tests

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -181,6 +181,8 @@ final class AppSettings {
     private(set) var accountProviders = ["matrix.i.tchap.gouv.fr"]
     #elseif IS_TCHAP_PRODUCTION
     private(set) var accountProviders = ["matrix.agent.dinum.tchap.gouv.fr"]
+    #elseif IS_TCHAP_UNIT_TESTS
+    private(set) var accountProviders = ["matrix.agent.dinum.tchap.gouv.fr"]
     #else
     private(set) var accountProviders = ["matrix.org"]
     #endif

--- a/TchapX/SupportingFiles/target-UITests.yml
+++ b/TchapX/SupportingFiles/target-UITests.yml
@@ -54,8 +54,13 @@ targets:
         APP_DISPLAY_NAME: TchapX # The name used in the application.
         PRODUCT_NAME: TchapX-UITests
         PRODUCT_BUNDLE_IDENTIFIER: ${BASE_BUNDLE_IDENTIFIER}.ui.tests
-      debug:
-      release:
+      configs:
+      # This is required to remove the $(inherited) flags
+      # which would prevent SnapshotTesting to be imported in UI Tests
+        debug:
+          OTHER_SWIFT_FLAGS: ["-DDEBUG"]
+        release:
+          OTHER_SWIFT_FLAGS: ["-DRELEASE"]
 
     sources:
     - path: ../../UITests/Sources

--- a/TchapX/SupportingFiles/target-unitTests.yml
+++ b/TchapX/SupportingFiles/target-unitTests.yml
@@ -33,6 +33,7 @@ targets:
     dependencies:
     - target: TchapX-Production
     - package: MatrixRustSDK
+    - package: AsyncAlgorithms
 
     info:
       path: ../UnitTests/SupportingFiles/Info.plist

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
@@ -7,6 +7,8 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
 #if IS_TCHAP_UNIT_TESTS
 @testable import TchapX_Production
 #else

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -30,6 +30,9 @@ class AttributedStringBuilderV1Tests: XCTestCase {
     private var attributedStringBuilder: AttributedStringBuilder!
     private let maxHeaderPointSize = ceil(UIFont.preferredFont(forTextStyle: .body).pointSize * 1.2)
     
+    // Tchap: adapt test
+    fileprivate let homeServerName = "tchap.gouv.fr"
+    
     override func setUp() async throws {
         attributedStringBuilder = AttributedStringBuilder(mentionBuilder: MentionBuilder())
     }
@@ -238,7 +241,9 @@ class AttributedStringBuilderV1Tests: XCTestCase {
     func testUserIDLink() {
         let userID = "@user:matrix.org"
         let string = "The user is \(userID)."
-        let expectedLink = "https://matrix.to/#/\(userID)"
+        // Tchap: adapt test
+//        let expectedLink = "https://matrix.to/#/\(userID)"
+        let expectedLink = "https://\(homeServerName)/#/\(userID)"
         checkLinkIn(attributedString: attributedStringBuilder.fromHTML(string), expectedLink: expectedLink, expectedRuns: 3)
         checkLinkIn(attributedString: attributedStringBuilder.fromPlain(string), expectedLink: expectedLink, expectedRuns: 3)
     }
@@ -246,7 +251,9 @@ class AttributedStringBuilderV1Tests: XCTestCase {
     func testRoomAliasLink() {
         let roomAlias = "#room:matrix.org"
         let string = "The room is \(roomAlias)."
-        guard let expectedLink = URL(string: "https://matrix.to/#/\(roomAlias)") else {
+        // Tchap: adapt test
+//        guard let expectedLink = URL(string: "https://matrix.to/#/\(roomAlias)") else {
+        guard let expectedLink = URL(string: "https://\(homeServerName)/#/\(roomAlias)") else {
             XCTFail("The expected link should be valid.")
             return
         }
@@ -459,11 +466,15 @@ class AttributedStringBuilderV1Tests: XCTestCase {
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
         XCTAssertNotNil(attributedStringFromHTML?.attachment)
         XCTAssertEqual(attributedStringFromHTML?.userID, "@test:matrix.org")
-        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://matrix.to/#/@test:matrix.org")
+        // Tchap: adapt test
+//        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://matrix.to/#/@test:matrix.org")
+        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://\(homeServerName)/#/@test:matrix.org")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
         XCTAssertNotNil(attributedStringFromPlain?.attachment)
         XCTAssertEqual(attributedStringFromPlain?.userID, "@test:matrix.org")
-        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://matrix.to/#/@test:matrix.org")
+        // Tchap: adapt test
+//        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://matrix.to/#/@test:matrix.org")
+        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://\(homeServerName)/#/@test:matrix.org")
     }
     
     func testRoomIDPermalinkMentionAttachment() {
@@ -495,11 +506,15 @@ class AttributedStringBuilderV1Tests: XCTestCase {
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
         XCTAssertNotNil(attributedStringFromHTML?.attachment)
         XCTAssertEqual(attributedStringFromHTML?.roomAlias, "#test:matrix.org")
-        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://matrix.to/#/%23test:matrix.org")
+        // Tchap: adapt test
+//        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://matrix.to/#/%23test:matrix.org")
+        XCTAssertEqual(attributedStringFromHTML?.link?.absoluteString, "https://\(homeServerName)/#/%23test:matrix.org")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
         XCTAssertNotNil(attributedStringFromPlain?.attachment)
         XCTAssertEqual(attributedStringFromHTML?.roomAlias, "#test:matrix.org")
-        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://matrix.to/#/%23test:matrix.org")
+        // Tchap: adapt test
+//        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://matrix.to/#/%23test:matrix.org")
+        XCTAssertEqual(attributedStringFromPlain?.link?.absoluteString, "https://\(homeServerName)/#/%23test:matrix.org")
     }
     
     func testEventRoomIDPermalinkMentionAttachment() {

--- a/UnitTests/Sources/AuthenticationServiceTests.swift
+++ b/UnitTests/Sources/AuthenticationServiceTests.swift
@@ -86,7 +86,9 @@ class AuthenticationServiceTests: XCTestCase {
         }
         
         XCTAssertEqual(service.flow, .login)
-        XCTAssertEqual(service.homeserver.value, .init(address: "matrix.org", loginMode: .unknown))
+        // Tchap: adapt test
+//        XCTAssertEqual(service.homeserver.value, .init(address: "matrix.org", loginMode: .unknown))
+        XCTAssertEqual(service.homeserver.value, .init(address: "matrix.agent.dinum.tchap.gouv.fr", loginMode: .unknown))
     }
     
     // MARK: - Helpers

--- a/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
@@ -8,7 +8,14 @@
 import XCTest
 
 import Combine
+
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class ChatsFlowCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -27,6 +27,9 @@ class ComposerToolbarViewModelTests: XCTestCase {
     private var completionSuggestionServiceMock: CompletionSuggestionServiceMock!
     private var draftServiceMock: ComposerDraftServiceMock!
 
+    // Tchap: adapt test
+    private let homeServerName = "tchap.gouv.fr"
+    
     override func setUp() {
         AppSettings.resetAllSettings()
         appSettings = AppSettings()
@@ -132,7 +135,9 @@ class ComposerToolbarViewModelTests: XCTestCase {
         viewModel.context.send(viewAction: .selectedSuggestion(suggestion))
         
         // The display name can be used for HTML injection in the rich text editor and it's useless anyway as the clients don't use it when resolving display names
-        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://matrix.to/#/@test:matrix.org\">@test:matrix.org</a> ")
+        // Tchap: adapt test
+//        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://matrix.to/#/@test:matrix.org\">@test:matrix.org</a> ")
+        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://\(homeServerName)/#/@test:matrix.org\">@test:matrix.org</a> ")
     }
     
     func testSelectedRoomSuggestion() {
@@ -147,7 +152,9 @@ class ComposerToolbarViewModelTests: XCTestCase {
         
         // The display name can be used for HTML injection in the rich text editor and it's useless anyway as the clients don't use it when resolving display names
 
-        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://matrix.to/#/%23room-alias:matrix.org\">#room-alias:matrix.org</a> ")
+        // Tchap: adapt test
+//        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://matrix.to/#/%23room-alias:matrix.org\">#room-alias:matrix.org</a> ")
+        XCTAssertEqual(wysiwygViewModel.content.html, "<a href=\"https://\(homeServerName)/#/%23room-alias:matrix.org\">#room-alias:matrix.org</a> ")
     }
     
     func testAllUsersSuggestion() {

--- a/UnitTests/Sources/DeferredFulfillmentTests.swift
+++ b/UnitTests/Sources/DeferredFulfillmentTests.swift
@@ -5,7 +5,14 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
+
 import XCTest
 
 class DeferredFulfillmentTests: XCTestCase {

--- a/UnitTests/Sources/EmojiPickerScreenViewModelTests.swift
+++ b/UnitTests/Sources/EmojiPickerScreenViewModelTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 final class EmojiPickerScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/NavigationTabCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationTabCoordinatorTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class NavigationTabCoordinatorTests: XCTestCase {

--- a/UnitTests/Sources/PermalinkTests.swift
+++ b/UnitTests/Sources/PermalinkTests.swift
@@ -17,28 +17,33 @@ import XCTest
 
 /// Just for API sanity checking, they're already properly tested in the SDK/Ruma
 class PermalinkTests: XCTestCase {
+    // Tchap: adapt test
+    private let homeServerName = "tchap.gouv.fr"
+
     func testUserIdentifierPermalink() {
         let invalidUserId = "This1sN0tV4lid!@#$%^&*()"
         XCTAssertNil(try? matrixToUserPermalink(userId: invalidUserId))
         
         let validUserId = "@abcdefghijklmnopqrstuvwxyz1234567890._-=/:matrix.org"
-        XCTAssertEqual(try? matrixToUserPermalink(userId: validUserId), .some("https://matrix.to/#/@abcdefghijklmnopqrstuvwxyz1234567890._-=%2F:matrix.org"))
+        // Tchap: handle permalinks
+//        XCTAssertEqual(try? matrixToUserPermalink(userId: validUserId), .some("https://matrix.to/#/@abcdefghijklmnopqrstuvwxyz1234567890._-=%2F:matrix.org"))
+        XCTAssertEqual(try? matrixToUserPermalink(userId: validUserId), .some("https://\(homeServerName)/#/@abcdefghijklmnopqrstuvwxyz1234567890._-=%2F:matrix.org"))
     }
     
     func testPermalinkDetection() {
         var url: URL = "https://www.matrix.org"
         // Tchap: handle permalinks
 //        XCTAssertNil(parseMatrixEntityFrom(uri: url.absoluteString))
-        let tchapNilUrl = URL(string: "")! // swiftlint:disable:this force_unwrapping
-        var tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
-        XCTAssert(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString) == nil)
+        let tchapBadUrl = URL(string: "badScheme://badHost.ext")! // swiftlint:disable:this force_unwrapping
+        var tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
+        XCTAssertNil(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString))
 
         url = "https://matrix.to/#/@bob:matrix.org?via=matrix.org"
         // Tchap: handle permalinks
 //        XCTAssertEqual(parseMatrixEntityFrom(uri: url.absoluteString),
 //                       MatrixEntity(id: .user(id: "@bob:matrix.org"),
 //                                    via: ["matrix.org"]))
-        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
+        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
         XCTAssertEqual(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString),
                        MatrixEntity(id: .user(id: "@bob:matrix.org"),
                                     via: ["matrix.org"]))
@@ -48,7 +53,7 @@ class PermalinkTests: XCTestCase {
 //        XCTAssertEqual(parseMatrixEntityFrom(uri: url.absoluteString),
 //                       MatrixEntity(id: .room(id: "!roomidentifier:matrix.org"),
 //                                    via: ["matrix.org"]))
-        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
+        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
         XCTAssertEqual(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString),
                        MatrixEntity(id: .room(id: "!roomidentifier:matrix.org"),
                                     via: ["matrix.org"]))
@@ -58,7 +63,7 @@ class PermalinkTests: XCTestCase {
 //        XCTAssertEqual(parseMatrixEntityFrom(uri: url.absoluteString),
 //                       MatrixEntity(id: .roomAlias(alias: "#roomalias:matrix.org"),
 //                                    via: ["matrix.org"]))
-        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
+        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
         XCTAssertEqual(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString),
                        MatrixEntity(id: .roomAlias(alias: "#roomalias:matrix.org"),
                                     via: ["matrix.org"]))
@@ -68,7 +73,7 @@ class PermalinkTests: XCTestCase {
 //        XCTAssertEqual(parseMatrixEntityFrom(uri: url.absoluteString),
 //                       MatrixEntity(id: .eventOnRoomId(roomId: "!roomidentifier:matrix.org", eventId: "$eventidentifier"),
 //                                    via: ["matrix.org"]))
-        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
+        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
         XCTAssertEqual(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString),
                        MatrixEntity(id: .eventOnRoomId(roomId: "!roomidentifier:matrix.org", eventId: "$eventidentifier"),
                                     via: ["matrix.org"]))
@@ -78,7 +83,7 @@ class PermalinkTests: XCTestCase {
 //        XCTAssertEqual(parseMatrixEntityFrom(uri: url.absoluteString),
 //                       MatrixEntity(id: .eventOnRoomAlias(alias: "#roomalias:matrix.org", eventId: "$eventidentifier"),
 //                                    via: ["matrix.org"]))
-        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapNilUrl
+        tchapPermalink = TchapPermalinks.convert(permalinkUri: url) ?? tchapBadUrl
         XCTAssertEqual(parseMatrixEntityFrom(uri: tchapPermalink.absoluteString),
                        MatrixEntity(id: .eventOnRoomAlias(alias: "#roomalias:matrix.org", eventId: "$eventidentifier"),
                                     via: ["matrix.org"]))

--- a/UnitTests/Sources/RemotePreferenceTests.swift
+++ b/UnitTests/Sources/RemotePreferenceTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class RemotePreferenceTests: XCTestCase {
     func testOverrideAndReset() {

--- a/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
@@ -507,7 +507,9 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         notificationSettingsProxyMock.callbacks.send(.settingsDidChange)
         try await deferred.fulfill()
         
-        XCTAssertEqual(context.viewState.notificationSettingsState.label, "Default")
+        // Tchap: adapt test
+//        XCTAssertEqual(context.viewState.notificationSettingsState.label, "Default")
+        XCTAssertEqual(context.viewState.notificationSettingsState.label, L10n.screenRoomDetailsNotificationModeDefault)
     }
     
     func testNotificationCustomMode() async throws {
@@ -518,7 +520,9 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         notificationSettingsProxyMock.callbacks.send(.settingsDidChange)
         try await deferred.fulfill()
         
-        XCTAssertEqual(context.viewState.notificationSettingsState.label, "Custom")
+        // Tchap: adapt test
+//        XCTAssertEqual(context.viewState.notificationSettingsState.label, "Custom")
+        XCTAssertEqual(context.viewState.notificationSettingsState.label, L10n.screenRoomDetailsNotificationModeCustom)
     }
     
     func testNotificationRoomMuted() async throws {

--- a/UnitTests/Sources/RoomEventStringBuilderTests.swift
+++ b/UnitTests/Sources/RoomEventStringBuilderTests.swift
@@ -33,8 +33,10 @@ class RoomEventStringBuilderTests: XCTestCase {
     
     func testSenderPrefix() {
         let ownMessageString = stringBuilder.buildAttributedString(for: makeMessageItem(senderID: ownUserID, senderDisplayName: "Alice"))
-        XCTAssertEqual(ownMessageString?.string, "You: Hello, World!", "Your own messages should be prefixed with 'You'")
-        
+        // Tchap; adapt test
+//        XCTAssertEqual(ownMessageString?.string, "You: Hello, World!", "Your own messages should be prefixed with 'You'")
+        XCTAssertEqual(ownMessageString?.string, "\(L10n.commonYou): Hello, World!", "Your own messages should be prefixed with 'You'")
+
         let otherMessageString = stringBuilder.buildAttributedString(for: makeMessageItem(senderID: "@bob:matrix.org", senderDisplayName: "Bob"))
         XCTAssertEqual(otherMessageString?.string, "Bob: Hello, World!", "Everyone else's messages should be prefixed with their display name.")
         
@@ -57,10 +59,14 @@ class RoomEventStringBuilderTests: XCTestCase {
         XCTAssertEqual(otherEmoteString?.string, "* Bob sighs", "Everyone else's emotes should contain their display name.")
         
         let ownPollString = stringBuilder.buildAttributedString(for: makePollItem(senderID: ownUserID, senderDisplayName: "Alice"))
-        XCTAssertEqual(ownPollString?.string, "You: Poll: Which is better?", "Your own polls should be prefixed with 'You'")
-        
+        // Tchap; adapt test
+//        XCTAssertEqual(ownPollString?.string, "You: Poll: Which is better?", "Your own polls should be prefixed with 'You'")
+        XCTAssertEqual(ownPollString?.string, "\(L10n.commonYou): \(L10n.commonPollSummary("Which is better?"))", "Your own polls should be prefixed with 'You'")
+
         let otherPollString = stringBuilder.buildAttributedString(for: makePollItem(senderID: "@bob:matrix.org", senderDisplayName: "Bob"))
-        XCTAssertEqual(otherPollString?.string, "Bob: Poll: Which is better?", "Everyone else's polls should be prefixed with their display name.")
+        // Tchap; adapt test
+//        XCTAssertEqual(otherPollString?.string, "Bob: Poll: Which is better?", "Everyone else's polls should be prefixed with their display name.")
+        XCTAssertEqual(otherPollString?.string, "Bob: \(L10n.commonPollSummary("Which is better?"))", "Everyone else's polls should be prefixed with their display name.")
     }
     
     // MARK: - Helpers

--- a/UnitTests/Sources/RoomRolesAndPermissionsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomRolesAndPermissionsScreenViewModelTests.swift
@@ -55,7 +55,11 @@ class RoomRolesAndPermissionsScreenViewModelTests: XCTestCase {
         context.send(viewAction: .editOwnUserRole)
         XCTAssertNotNil(context.alertInfo)
         
-        context.alertInfo?.verticalButtons?.first { $0.title.localizedStandardContains("moderator") }?.action?()
+        context.alertInfo?.verticalButtons?.first {
+            // Tchap: adapt test
+//            $0.title.localizedStandardContains("moderator")
+            $0.title.localizedStandardContains("moderator") || $0.title.localizedStandardContains("modérateur")
+        }?.action?()
         
         try await Task.sleep(for: .milliseconds(100))
         
@@ -70,7 +74,11 @@ class RoomRolesAndPermissionsScreenViewModelTests: XCTestCase {
         context.send(viewAction: .editOwnUserRole)
         XCTAssertNotNil(context.alertInfo)
         
-        context.alertInfo?.verticalButtons?.first { $0.title.localizedStandardContains("member") }?.action?()
+        context.alertInfo?.verticalButtons?.first {
+            // Tchap: adapt test
+//            $0.title.localizedStandardContains("member")
+            $0.title.localizedStandardContains("member") || $0.title.localizedStandardContains("membre")
+        }?.action?()
         
         try await Task.sleep(for: .milliseconds(100))
         

--- a/UnitTests/Sources/RoomSummaryProviderTests.swift
+++ b/UnitTests/Sources/RoomSummaryProviderTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 final class RoomSummaryProviderTests: XCTestCase {
     var appSettings: AppSettings!

--- a/UnitTests/Sources/RoomTests.swift
+++ b/UnitTests/Sources/RoomTests.swift
@@ -8,7 +8,13 @@
 import MatrixRustSDK
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class RoomTests: XCTestCase {
     func testCallIntent() async throws {

--- a/UnitTests/Sources/SpaceListScreenViewModelTests.swift
+++ b/UnitTests/Sources/SpaceListScreenViewModelTests.swift
@@ -8,7 +8,13 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 @MainActor
 class SpaceListScreenViewModelTests: XCTestCase {

--- a/UnitTests/Sources/SpaceScreenViewModelTests.swift
+++ b/UnitTests/Sources/SpaceScreenViewModelTests.swift
@@ -8,7 +8,14 @@
 import Combine
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
+
 import MatrixRustSDK
 
 @MainActor

--- a/UnitTests/Sources/URLTests.swift
+++ b/UnitTests/Sources/URLTests.swift
@@ -7,7 +7,13 @@
 
 import XCTest
 
+// Tchap: specify target for unit tests
+// @testable import ElementX
+#if IS_TCHAP_UNIT_TESTS
+@testable import TchapX_Production
+#else
 @testable import ElementX
+#endif
 
 class URLTests: XCTestCase {
     func testURLDirectoryName() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,35 @@ end
 lane :unit_tests do |options|
   reset_simulator = ENV.key?('CI')
   
+  #Tchap: generate empty 'generated files' to avoid Xcode error: files not found.
+  dest = "../TchapX/main/Sources/Generated"
+  FileUtils.mkdir_p dest
+  Dir.chdir dest do
+      files = ["TchapAssets.swift", "TchapStrings.swift", "TchapStrings+Untranslated.swift"]
+      files.each do |filename|
+        if !File.exist?(filename)
+          FileUtils.touch filename
+        end
+      end
+  end
+  
+  #Tchap: generate Secrets.swift file if it doesn't exist.
+  destFolder = "../Secrets"
+  destFile = "Secrets.swift"
+  if !File.exist?("#{destFolder}/#{destFile}")
+    FileUtils.mkdir_p destFolder
+    File.open("#{destFolder}/#{destFile}", "w") do |f|
+      f.write(%q(  enum Secrets {
+      static let sentryDSN: String? = "https://username@sentry.localhost/project_id"
+      static let sentryRustDSN: String? = "https://username@sentry.localhost/project_id"
+      static let postHogHost: String? = "https://posthog.localhost"
+      static let postHogAPIKey: String? = "your_key"
+      static let rageshakeURL: String? = "https://rageshake.localhost/submit"
+      static let mapLibreAPIKey: String? = "your_key"
+      }))
+    end  
+  end
+  
   # Tchap: generate xcode project because .xcodeproj files are not gitted.
   xcodegen(
     spec: "project-tchap-x.yml"


### PR DESCRIPTION
Fix #210 

Quelques unit tests ne passent toujours pas : 
- TimelineMediaPreviewViewModelTests
- un peu de ComposerToolbarViewModelTests
- un peu de CompletionSuggestionServiceTests
- ServerConfirmationScreenViewModelTests.swift