### PR TITLE
Rename `room.isPublicAndNotPrivateUnencrypted` -> `room.canDisplayPublicBadge`

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/AvatarHeaderView.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/AvatarHeaderView.swift
@@ -59,7 +59,7 @@ struct AvatarHeaderView<Footer: View>: View {
         
         var badges = [Badge]()
         badges.append(.encrypted(room.isEncrypted))
-        if room.isPublicAndNotPrivateUnencrypted {
+        if room.canDisplayPublicBadge {
             badges.append(.public)
         }
         self.badges = badges

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -94,7 +94,7 @@ struct RoomScreenViewStateBindings {
     var isPublic: Bool?
     var isOpenToExternalUsers: Bool?
     var visibilityInRoomDirectory: RoomVisibility!
-    var isPublicAndNotPrivateUnencrypted: Bool!
+    var canDisplayPublicBadge: Bool!
 }
 
 enum RoomScreenFooterViewAction {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -350,7 +350,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.bindings.isPublic = roomProxy.details.isPublic
             // Tchap: read the `external access` value in the `accessRules` of the room.
             state.bindings.isOpenToExternalUsers = roomProxy.details.accessRule == .unrestricted
-            state.bindings.isPublicAndNotPrivateUnencrypted = roomProxy.details.isPublicAndNotPrivateUnencrypted
+            state.bindings.canDisplayPublicBadge = roomProxy.details.canDisplayPublicBadge
         }
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -187,7 +187,7 @@ struct RoomScreen: View {
                            roomPropertiesBadgesView:
                            // Tchap: add badges
                            TchapRoomHeaderViewRoomPropertiesBadgesView(isEncrypted: $context.isEncrypted,
-                                                                       isPublic: $context.isPublicAndNotPrivateUnencrypted,
+                                                                       isPublic: $context.canDisplayPublicBadge,
                                                                        isOpenToExternalUsers: $context.isOpenToExternalUsers),
                            mediaProvider: context.mediaProvider)
                 // Using a button stops it from getting truncated in the navigation bar

--- a/ElementX/Sources/Services/Room/RoomDetails.swift
+++ b/ElementX/Sources/Services/Room/RoomDetails.swift
@@ -22,6 +22,7 @@ struct RoomDetails {
     let accessRule: AccessRule?
     let visibility: RoomVisibility
     // Tchap: helper to write the condition once. Private Unencrypted rooms accessible by link are seen as `isPublic`, like Public Forums.
-    // But their `visibility` is `.private` in order to not be listed in room directories. This visibility makes the difference with Forums (which are `.public`).
-    var isPublicAndNotPrivateUnencrypted: Bool { isPublic && visibility == .public }
+    // But their `visibility` is `.private` in order to not be listed in room directories.
+    // The AccessRule.visibility value makes the difference between (Forums) which are `.public`, and (Private Unencrypted rooms accessible by link) which are `.private`.
+    var canDisplayPublicBadge: Bool { visibility == .public }
 }


### PR DESCRIPTION
Fix #216 

Forum public :
<img width="1206" height="389" alt="image" src="https://github.com/user-attachments/assets/51355791-ceab-4d05-a1d9-e6ab4d41531e" />

Salon privé non-chiffré accessible par lien :
<img width="1206" height="348" alt="image" src="https://github.com/user-attachments/assets/5bfe879e-e751-4c3b-bf69-52bc9cc03aba" />
