### PR TITLE
Remplacer "CGU" par "Modalités d'utilisation"

### DIFF
--- a/TchapX/main/Resources/Localizations/fr.lproj/TchapLocalizable.strings
+++ b/TchapX/main/Resources/Localizations/fr.lproj/TchapLocalizable.strings
@@ -11,7 +11,7 @@ common_faq = "Foire Aux Questions";
 common_user_is_external = "INVITÉ EXTERNE";
 common_email = "Email";
 
-legal_terms_of_use = "Conditions Générales d'Utilisation";
+legal_terms_of_use = "Modalités d'utilisation";
 legal_privacy_policy = "Politique de confidentialité";
 
 screen_onboarding_welcome_title = "Bienvenue dans Tchap";


### PR DESCRIPTION
Fix #149 

<img width="1206" height="978" alt="image" src="https://github.com/user-attachments/assets/5de6c99d-2a84-4a5e-9ecc-ff5d549f98c2" />
