### PR TITLE
Modifier la traduction française du bouton Mute dans un salon

### DIFF
--- a/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
@@ -238,7 +238,7 @@
 "common_message_layout" = "Mode d’affichage des messages";
 "common_message_removed" = "Message supprimé";
 "common_modern" = "Moderne";
-"common_mute" = "Mettre en sourdine";
+"common_mute" = "Sourdine"; // Tchap
 "common_name_and_id" = "%1$@ (%2$@)";
 "common_no_results" = "Aucun résultat";
 "common_no_room_name" = "Salon sans nom";


### PR DESCRIPTION
Fix #229 

<img width="1206" height="1524" alt="image" src="https://github.com/user-attachments/assets/ec649e9e-3d72-469a-8a1b-1f0a21813c91" />
