### PR TITLE
Fix neutral badge background color

### DIFF
--- a/TchapX/main/Sources/Other/Screens/TchapBadge/TchapBadgeLabelUsage.swift
+++ b/TchapX/main/Sources/Other/Screens/TchapBadge/TchapBadgeLabelUsage.swift
@@ -52,7 +52,7 @@ public enum TchapBadgeLabelUsage {
         case .userIsExternal: CompoundCoreColorTokens.orange300
         case .roomIsEncrypted: .compound.bgBadgeAccent
         case .roomIsNotEncrypted: .compound.bgBadgeInfo
-        case .roomIsPublic: .compound.bgBadgeInfo
+        case .roomIsPublic: .compound.bgBadgeDefault
         case .roomIsAccessibleToExternals: CompoundCoreColorTokens.orange300
         }
     }


### PR DESCRIPTION
Fix #234 

<img width="800" height="348" alt="image" src="https://github.com/user-attachments/assets/f4f769c7-9727-44f8-92de-87792b5830da" />

<img width="800" height="246" alt="image" src="https://github.com/user-attachments/assets/0611f57c-6701-4ba2-8dec-8f62b1d2ec70" />
