### PR TITLE
Use new semantic colors for badges

### DIFF
--- a/TchapX/main/Sources/Other/Screens/TchapBadge/TchapBadgeLabelUsage.swift
+++ b/TchapX/main/Sources/Other/Screens/TchapBadge/TchapBadgeLabelUsage.swift
@@ -29,31 +29,31 @@ public enum TchapBadgeLabelUsage {
 
     var titleColor: Color {
         switch self {
-        case .userIsExternal: CompoundCoreColorTokens.orange1100
+        case .userIsExternal: .compound.textBadgeExternal
         case .roomIsEncrypted: .compound.textBadgeAccent
-        case .roomIsNotEncrypted: .compound.textBadgeInfo
-        case .roomIsPublic: .compound.textBadgeInfo
-        case .roomIsAccessibleToExternals: CompoundCoreColorTokens.orange1100
+        case .roomIsNotEncrypted: .compound.textBadgeDefault
+        case .roomIsPublic: .compound.textBadgeDefault
+        case .roomIsAccessibleToExternals: .compound.textBadgeExternal
         }
     }
 
     var iconColor: Color {
         switch self {
-        case .userIsExternal: .compound.textDecorative6
-        case .roomIsEncrypted: .compound.iconAccentPrimary
-        case .roomIsNotEncrypted: .compound.iconInfoPrimary
-        case .roomIsPublic: .compound.iconInfoPrimary
-        case .roomIsAccessibleToExternals: .compound.textDecorative6
+        case .userIsExternal: .compound.iconBadgeExternal
+        case .roomIsEncrypted: .compound.iconBadgeAccent
+        case .roomIsNotEncrypted: .compound.iconBadgeDefault
+        case .roomIsPublic: .compound.iconBadgeDefault
+        case .roomIsAccessibleToExternals: .compound.iconBadgeExternal
         }
     }
 
     var backgroundColor: Color {
         switch self {
-        case .userIsExternal: CompoundCoreColorTokens.orange300
+        case .userIsExternal: .compound.bgBadgeExternal
         case .roomIsEncrypted: .compound.bgBadgeAccent
-        case .roomIsNotEncrypted: .compound.bgBadgeInfo
+        case .roomIsNotEncrypted: .compound.bgBadgeDefault
         case .roomIsPublic: .compound.bgBadgeDefault
-        case .roomIsAccessibleToExternals: CompoundCoreColorTokens.orange300
+        case .roomIsAccessibleToExternals: .compound.bgBadgeExternal
         }
     }
 


### PR DESCRIPTION
Fix #240 

<img width="800" height="527" alt="image" src="https://github.com/user-attachments/assets/9109cf87-697b-434c-9458-f0710a71d2d2" />

<img width="800" height="537" alt="image" src="https://github.com/user-attachments/assets/1ca135d2-2df0-4e7b-86d8-7410db12170e" />
