### PR TITLE
Fix corner radius on nameTextField

### DIFF
--- a/ElementX/Sources/Screens/CreateRoomScreen/View/CreateRoomScreen.swift
+++ b/ElementX/Sources/Screens/CreateRoomScreen/View/CreateRoomScreen.swift
@@ -57,7 +57,15 @@ struct CreateRoomScreen: View {
         .alert(item: $context.alertInfo)
         .shouldScrollOnKeyboardDidShow(focus == .alias, to: Focus.alias)
     }
-    
+
+    private var nameTextFieldShape: AnyShape {
+        if #available(iOS 26, *) {
+            AnyShape(ConcentricRectangle(corners: .concentric(minimum: 26)))
+        } else {
+            AnyShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
     private var roomSection: some View {
         Section {
             HStack(alignment: .center, spacing: 16) {
@@ -84,7 +92,7 @@ struct CreateRoomScreen: View {
                         .accessibilityIdentifier(A11yIdentifiers.createRoomScreen.roomName)
                         .padding(.horizontal, ListRowPadding.horizontal)
                         .padding(.vertical, ListRowPadding.vertical)
-                        .background(.compound.bgCanvasDefaultLevel1, in: RoundedRectangle(cornerRadius: 12))
+                        .background(.compound.bgCanvasDefaultLevel1, in: nameTextFieldShape)
                 }
             }
             .listRowInsets(.init())


### PR DESCRIPTION
#258 

## Screenshots 
**Rendu iOS 26** 

<img width="462" height="899" alt="Screenshot 2026-02-09 at 21 11 34" src="https://github.com/user-attachments/assets/05836fc3-cf12-43c2-93cf-5b4da303eba7" />

**Rendu iOS 18.6** 

<img width="457" height="887" alt="Screenshot 2026-02-09 at 21 15 28" src="https://github.com/user-attachments/assets/c7c5db7c-ba87-4359-9555-ae01c1816c82" />


## 

J'ai repris le fix par Element X dans le commit https://github.com/element-hq/element-x-ios/commit/648caa4e823ab6f39b1f850e8bf966a8f30e80f9