### PR TITLE
Sianay/270 param salons

### DIFF
--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -173,7 +173,9 @@ struct SecurityAndPrivacyScreen: View {
     private func addressSection(canonicalAlias: String) -> some View {
         Section {
             ListRow(label: .plain(title: canonicalAlias),
-                    kind: .navigationLink { context.send(viewAction: .editAddress) })
+                    // Tchap: Make address read-only
+//                    kind: .navigationLink { context.send(viewAction: .editAddress) })
+                    kind: .label)
             roomDirectoryVisibilityRow
         } header: {
             Text(L10n.screenSecurityAndPrivacyRoomAddressSectionHeader)

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -48,12 +48,15 @@ struct SecurityAndPrivacyScreen: View {
     
     private var roomAccessSection: some View {
         Section {
-            ListRow(label: .default(title: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionTitle,
-                                    description: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionDescription,
-                                    icon: \.public,
-                                    iconAlignment: .top),
-                    kind: .selection(isSelected: context.desiredSettings.accessType == .anyone) { context.desiredSettings.accessType = .anyone })
-            
+            // Tchap: Hide public option for invite-only rooms
+            if context.viewState.currentSettings.accessType != .inviteOnly {
+                ListRow(label: .default(title: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionTitle,
+                                        description: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionDescription,
+                                        icon: \.public,
+                                        iconAlignment: .top),
+                        kind: .selection(isSelected: context.desiredSettings.accessType == .anyone) { context.desiredSettings.accessType = .anyone })
+            }
+
             if context.viewState.isSpaceMembersOptionAvailable {
                 ListRow(label: .default(title: L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionTitle,
                                         description: context.viewState.spaceMembersDescription,

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -28,7 +28,9 @@ struct SecurityAndPrivacyScreen: View {
             }
             
             if !context.viewState.isSpace {
-                if context.viewState.canEnableEncryption {
+                // Tchap: Hide encryption section for public rooms
+//                if context.viewState.canEnableEncryption {
+                if context.viewState.canEnableEncryption, context.desiredSettings.accessType != .anyone {
                     encryptionSection
                 }
                 if context.viewState.canEditHistoryVisibility {


### PR DESCRIPTION
cf #270 


**Salon public** 
- Ne pas pouvoir modifier l'adresse  du salon 
- Enlever l'option pour chiffrer le salon
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-03 at 10 28 05" src="https://github.com/user-attachments/assets/1852e206-8fd6-4e49-9038-2a868cffd95b" />

**Salon privé** 
- Ne pas pouvoir le changer en salon public 
- Pas d'addresse, pas d'option pour rendre visible dans l'annuaire -> déjà le cas sur un salon privé non accessible par lien
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-03 at 10 28 18" src="https://github.com/user-attachments/assets/7f4b440f-cfe4-4f39-9b69-2b23b6373ffd" />

La partie concernant les salons avec accès par lien sera à faire quand on traitera le ticket accès par lien