### PR TITLE
Utiliser la saisie du Code de vérification comme premier écran de vérification d'appareil lorsque c'est possible

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -908,7 +908,7 @@
 "screen_encryption_reset_title" = "Can't confirm? You’ll need to reset your identity.";
 "screen_identity_confirmation_cannot_confirm" = "Can't confirm?";
 "screen_identity_confirmation_create_new_recovery_key" = "Create a new verification code"; // Tchap
-"screen_identity_confirmation_subtitle" = "Verify this device to set up secure messaging.";
+"screen_identity_confirmation_subtitle" = "Choose a method to verify your device and access your Tchap account."; // Tchap
 "screen_identity_confirmation_title" = "Confirm your identity";
 "screen_identity_confirmation_use_another_device" = "Use another device";
 "screen_identity_confirmation_use_recovery_key" = "Use verification code"; // Tchap

--- a/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
@@ -908,9 +908,9 @@
 "screen_encryption_reset_title" = "Vous ne pouvez pas confirmer ? Vous devez réinitialiser votre identité.";
 "screen_identity_confirmation_cannot_confirm" = "Confirmation impossible ?";
 "screen_identity_confirmation_create_new_recovery_key" = "Créer un nouveau code de vérification"; // Tchap
-"screen_identity_confirmation_subtitle" = "Vérifier cette session pour configurer votre messagerie sécurisée.";
+"screen_identity_confirmation_subtitle" = "Choisissez une méthode pour vérifier votre appareil et accéder à votre compte Tchap."; //Tchap
 "screen_identity_confirmation_title" = "Confirmez votre identité";
-"screen_identity_confirmation_use_another_device" = "Utiliser une autre session";
+"screen_identity_confirmation_use_another_device" = "Utiliser un autre appareil"; // Tchap
 "screen_identity_confirmation_use_recovery_key" = "Utiliser le code de vérification"; // Tchap
 "screen_identity_confirmed_subtitle" = "Vous pouvez désormais lire ou envoyer des messages en toute sécurité, et toute personne avec qui vous discutez peut également faire confiance à cette session.";
 "screen_identity_confirmed_title" = "Session vérifiée";

--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -652,6 +652,10 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
             switch action {
             case .complete:
                 navigationSplitCoordinator.setSheetCoordinator(nil)
+            case .logout: // Tchap: add logout in recoveryKeyScreen
+                actionsSubject.send(.logout)
+            case .identityConfirmation: // Tchap: won't happen in isModallyPresented
+                break
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/FlowCoordinators/EncryptionSettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/EncryptionSettingsFlowCoordinator.swift
@@ -164,6 +164,8 @@ class EncryptionSettingsFlowCoordinator: FlowCoordinatorProtocol {
             switch action {
             case .complete:
                 navigationStackCoordinator.setSheetCoordinator(nil)
+            case .logout, .identityConfirmation:
+                break // Tchap: won't happen in isModallyPresented
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
@@ -246,7 +246,9 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
             
             switch (context.fromState, context.event, context.toState) {
             case (_, _, .identityConfirmation):
-                presentIdentityConfirmationScreen()
+                // Tchap: switch RecoveryKeyScreen and IdentityConfirmationScreen
+                // presentIdentityConfirmationScreen()
+                presentRecoveryKeyScreen()
             case (_, _, .identityConfirmed):
                 presentIdentityConfirmedScreen()
             case (_, _, .appLockSetup):
@@ -342,6 +344,10 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
         coordinator.actions
             .sink { action in
                 switch action {
+                case .logout: // Tchap: add logout in recoveryKeyScreen
+                    self.actionsSubject.send(.logout)
+                case .identityConfirmation: // Tchap: open other verification methods
+                    self.presentIdentityConfirmationScreen()
                 case .complete:
                     break // Moving to next state is Handled by the global session verification listener
                 }

--- a/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
@@ -246,9 +246,13 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
             
             switch (context.fromState, context.event, context.toState) {
             case (_, _, .identityConfirmation):
-                // Tchap: switch RecoveryKeyScreen and IdentityConfirmationScreen
-                // presentIdentityConfirmationScreen()
-                presentRecoveryKeyScreen()
+                // Tchap: Redirect to RecoveryKeyScreen if recovery is available
+                let recoveryState = userSession.sessionSecurityStatePublisher.value.recoveryState
+                if recoveryState == .enabled || recoveryState == .incomplete {
+                    presentRecoveryKeyScreen()
+                } else {
+                    presentIdentityConfirmationScreen()
+                }
             case (_, _, .identityConfirmed):
                 presentIdentityConfirmedScreen()
             case (_, _, .appLockSetup):

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1776,7 +1776,7 @@ internal enum L10n {
   internal static var screenIdentityConfirmationCannotConfirm: String { return L10n.tr("Localizable", "screen_identity_confirmation_cannot_confirm") }
   /// Create a new verification code
   internal static var screenIdentityConfirmationCreateNewRecoveryKey: String { return L10n.tr("Localizable", "screen_identity_confirmation_create_new_recovery_key") }
-  /// Verify this device to set up secure messaging.
+  /// Choose a method to verify your device and access your Tchap account.
   internal static var screenIdentityConfirmationSubtitle: String { return L10n.tr("Localizable", "screen_identity_confirmation_subtitle") }
   /// Confirm your identity
   internal static var screenIdentityConfirmationTitle: String { return L10n.tr("Localizable", "screen_identity_confirmation_title") }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenCoordinator.swift
@@ -17,6 +17,8 @@ struct SecureBackupRecoveryKeyScreenCoordinatorParameters {
 
 enum SecureBackupRecoveryKeyScreenCoordinatorAction {
     case complete
+    case logout // Tchap: add logout in recoveryKeyScreen
+    case identityConfirmation // Tchap: open other verification methods
 }
 
 final class SecureBackupRecoveryKeyScreenCoordinator: CoordinatorProtocol {
@@ -57,6 +59,10 @@ final class SecureBackupRecoveryKeyScreenCoordinator: CoordinatorProtocol {
                     fatalError()
                 }
                 self.actionsSubject.send(.complete)
+            case .logout: // Tchap: add logout in recoveryKeyScreen
+                self.actionsSubject.send(.logout)
+            case .identityConfirmation: // Tchap: open other verification methods
+                self.actionsSubject.send(.identityConfirmation)
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenModels.swift
@@ -11,6 +11,8 @@ import Foundation
 enum SecureBackupRecoveryKeyScreenViewModelAction {
     case done(mode: SecureBackupRecoveryKeyScreenViewMode)
     case cancel
+    case logout // Tchap: add logout in recoveryKeyScreen
+    case identityConfirmation // Tchap: open other verification methods
 }
 
 enum SecureBackupRecoveryKeyScreenViewMode {
@@ -84,4 +86,6 @@ enum SecureBackupRecoveryKeyScreenViewAction {
     case confirmKey
     case done
     case cancel
+    case logout // Tchap: add logout in recoveryKeyScreen
+    case identityConfirmation // Tchap: open other verification methods
 }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
@@ -84,6 +84,10 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
                                                  actionsSubject.send(.done(mode: state.mode))
                                              },
                                              secondaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil))
+        case .logout: // Tchap: add logout in recoveryKeyScreen
+            actionsSubject.send(.logout)
+        case .identityConfirmation: // Tchap: open other verification methods
+            actionsSubject.send(.identityConfirmation)
         }
     }
     

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
@@ -90,6 +90,15 @@ struct SecureBackupRecoveryKeyScreen: View {
             .buttonStyle(.compound(.primary))
             .disabled(context.confirmationRecoveryKey.isEmpty)
             .accessibilityIdentifier(A11yIdentifiers.secureBackupRecoveryKeyScreen.confirm)
+
+            // Tchap: open other verification methods
+            if context.viewState.isModallyPresented == false {
+                Button {
+                    context.send(viewAction: .identityConfirmation)
+                } label: {
+                    Text(TchapL10n.screenRecoveryKeyConfirmOtherMethod)
+                }
+            }
         }
     }
     
@@ -122,6 +131,13 @@ struct SecureBackupRecoveryKeyScreen: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button(L10n.actionCancel) {
                     context.send(viewAction: .cancel)
+                }
+            }
+            // Tchap: add logout in recoveryKeyScreen
+        } else {
+            ToolbarItem(placement: .destructiveAction) {
+                Button(L10n.actionSignout) {
+                    context.send(viewAction: .logout)
                 }
             }
         }

--- a/TchapX/main/Resources/Localizations/en.lproj/TchapLocalizable.strings
+++ b/TchapX/main/Resources/Localizations/en.lproj/TchapLocalizable.strings
@@ -89,3 +89,5 @@ content_scanner_scan_status_in_progress = "Scanning for virus…";
 content_scanner_scan_status_infected = "Content blocked";
 content_scanner_scan_status_not_found = "File no longer available";
 content_scanner_scan_status_error = "File temporarily unavailable";
+
+screen_recovery_key_confirm_other_method = "Other verification methods";

--- a/TchapX/main/Resources/Localizations/fr.lproj/TchapLocalizable.strings
+++ b/TchapX/main/Resources/Localizations/fr.lproj/TchapLocalizable.strings
@@ -89,3 +89,5 @@ content_scanner_scan_status_in_progress = "Analyse anti-virus…";
 content_scanner_scan_status_infected = "Contenu bloqué";
 content_scanner_scan_status_not_found = "Fichier indisponible";
 content_scanner_scan_status_error = "Fichier temporairement indisponible";
+
+screen_recovery_key_confirm_other_method = "Autres méthodes de vérification";

--- a/TchapX/main/Sources/Generated/TchapStrings.swift
+++ b/TchapX/main/Sources/Generated/TchapStrings.swift
@@ -135,6 +135,8 @@ internal enum TchapL10n {
   internal static func screenOnboardingWelcomeTitle(_ p1: Any) -> String {
     return TchapL10n.tr("TchapLocalizable", "screen_onboarding_welcome_title", String(describing: p1))
   }
+  /// Other verification methods
+  internal static var screenRecoveryKeyConfirmOtherMethod: String { return TchapL10n.tr("TchapLocalizable", "screen_recovery_key_confirm_other_method") }
   /// Join a public room
   internal static var screenRoomDirectorySearchTitle: String { return TchapL10n.tr("TchapLocalizable", "screen_room_directory_search_title") }
   /// Join a public room


### PR DESCRIPTION
Ticket #286

Utiliser la saisie du Code de vérification comme premier écran de vérification d'appareil

PR Android : https://github.com/tchapgouv/tchap-x-android/issues/114
