### PR TITLE
Correction : certaines conversations de salon apparaissent floutées 

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/RoomHeaderView.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/RoomHeaderView.swift
@@ -63,15 +63,15 @@ struct RoomHeaderView: View {
                             .font(.compound.bodyXS)
                             .foregroundStyle(.compound.textSecondary)
                     }
-                }
-                
-                if let dmRecipientVerificationState {
-                    VerificationBadge(verificationState: dmRecipientVerificationState, size: .xSmall, relativeTo: .compound.bodyMDSemibold)
-                }
-                
-                if let historySharingIcon {
-                    CompoundIcon(historySharingIcon, size: .xSmall, relativeTo: .compound.bodyMDSemibold)
-                        .foregroundStyle(.compound.iconInfoPrimary)
+                    
+                    if let dmRecipientVerificationState {
+                        VerificationBadge(verificationState: dmRecipientVerificationState, size: .xSmall, relativeTo: .compound.bodyMDSemibold)
+                    }
+                    
+                    if let historySharingIcon {
+                        CompoundIcon(historySharingIcon, size: .xSmall, relativeTo: .compound.bodyMDSemibold)
+                            .foregroundStyle(.compound.iconInfoPrimary)
+                    }
                 }
                 
                 // Tchap: additional room info


### PR DESCRIPTION
#363 

Bug dû à un cumul de badges sur l'entête du salon, on ne peut pas avoir plus de trois lignes sur un header ...

Sous iOS 26 : l'entête provoquait un bug UI qui floutait toute la conversation 
Sous iOS 18 : la conversation n'était pas floutée mais l'entête du salon apparaîssait cassé

