### PR TITLE
Correction sur la lisibilité des mentions en mode sombre

### DIFF
--- a/ElementX/Sources/Other/Pills/PillView.swift
+++ b/ElementX/Sources/Other/Pills/PillView.swift
@@ -15,11 +15,15 @@ struct PillView: View {
     let didChangeText: () -> Void
     
     var textColor: Color {
-        context.viewState.isOwnMention ? .compound.textBadgeAccent : .compound.textOnSolidPrimary
+        // :tchap: custom other mention textColor
+//        context.viewState.isOwnMention ? .compound.textBadgeAccent : .compound.textOnSolidPrimary
+        context.viewState.isOwnMention ? .compound.textBadgeAccent : .compound.textPrimary // :tchap:end:
     }
     
     var backgroundColor: Color {
-        context.viewState.isOwnMention ? .compound.bgBadgeAccent : .compound.bgBadgePrimary
+        // :tchap: custom other mention backgroundColor
+//        context.viewState.isOwnMention ? .compound.bgBadgeAccent : .compound.bgBadgePrimary
+        context.viewState.isOwnMention ? .compound.bgBadgeAccent : .compound.bgBadgeDefault // :tchap:end:
     }
     
     var body: some View {


### PR DESCRIPTION
 La couleur des mentions apparaissait en texte blanc sur fond blanc 

---
Avant

<img width="402" height="874" alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 12 11 55" src="https://github.com/user-attachments/assets/da6d17f4-6a50-4fd2-b449-b69ef3968ad9" />

Après
<img width="402" height="874"  alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 12 13 00" src="https://github.com/user-attachments/assets/f042f98c-82ca-4764-9c57-9a3115ef0916" />
