### PR TITLE
Connexion depuis Tchap Classique : l'email se pré-rempli au mauvais format 

### DIFF
--- a/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
@@ -117,7 +117,7 @@ class AuthenticationStartScreenViewModel: AuthenticationStartScreenViewModelType
                 state.bindings.showClassicAppBackupInstructions = true
             } else {
                 await configureAccountProvider(classicAppAccount.serverName,
-                                               loginHint: "mxid:\(classicAppAccount.userID)",
+                                               loginHint: convertMatrixIDToTchapEmail(classicAppAccount.userID), // :tchap: custom loginHint
                                                fallbackHomeserverURL: classicAppAccount.homeserverURL)
             }
         } else if let serverName = state.serverName {
@@ -126,6 +126,40 @@ class AuthenticationStartScreenViewModel: AuthenticationStartScreenViewModelType
             actionsSubject.send(.login) // No need to configure anything here, continue the flow.
         }
     }
+    
+    // :tchap: Convert Matrix ID format to Tchap email format
+    // passing it directly as mxid:@username-domain:homeserver does not seems to convert correctly in tchap email format
+    // we only convert when the local part contains exactly ONE hyphen,
+    // i.e. when the conversion is unambiguous. Otherwise we return nil
+    func convertMatrixIDToTchapEmail(_ matrixID: String) -> String? {
+        guard matrixID.hasPrefix("@") else {
+            return nil
+        }
+
+        guard let localPart = matrixID.dropFirst()
+            .split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            .first,
+            !localPart.isEmpty
+        else {
+            return nil
+        }
+
+        let localPartString = String(localPart)
+
+        guard localPartString.filter({ $0 == "-" }).count == 1 else {
+            return nil
+        }
+
+        let email = localPartString.replacingOccurrences(of: "-", with: "@")
+
+        guard let domainPart = email.split(separator: "@").last,
+              domainPart.contains(".")
+        else {
+            return nil
+        }
+
+        return email
+    } // :tchap:end
     
     private func configureAccountProvider(_ accountProvider: String, loginHint: String? = nil, fallbackHomeserverURL: URL? = nil) async {
         startLoading()

--- a/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
@@ -153,7 +153,7 @@ class AuthenticationStartScreenViewModel: AuthenticationStartScreenViewModelType
         let email = localPartString.replacingOccurrences(of: "-", with: "@")
 
         guard let domainPart = email.split(separator: "@").last,
-              domainPart.contains(".")
+              [".fr", ".com", ".net"].contains(where: { domainPart.hasSuffix($0) })
         else {
             return nil
         }

--- a/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
+++ b/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
@@ -410,6 +410,16 @@ final class AuthenticationStartScreenViewModelTests {
         
         #expect(result == nil, "Should return nil when there's no dash")
     }
+    
+    @Test("Convert Matrix ID with invalid domain suffix returns nil")
+    func convertMatrixIDToTchapEmailInvalidDomainSuffix() async {
+        await setupViewModel()
+
+        let matrixID = "@anatest2-yop2.tchap.incubateur.fr1:dev02.tchap.incubateur.net"
+        let result = viewModel.convertMatrixIDToTchapEmail(matrixID)
+
+        #expect(result == nil, "Should return nil when the email domain has an unsupported TLD")
+    }
 }
 
 extension AuthenticationStartScreenViewModelAction {

--- a/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
+++ b/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
@@ -358,6 +358,58 @@ final class AuthenticationStartScreenViewModelTests {
                              analyticsTermsURL: appSettings.analyticsTermsURL,
                              mapTilerConfiguration: AppSettings.bundledMapTilerConfiguration)
     }
+
+    // MARK: - Tchap Email Conversion Tests
+    
+    @Test("Convert valid Matrix ID with single dash to Tchap email")
+    func convertMatrixIDToTchapEmailValid() async {
+        await setupViewModel()
+        
+        let matrixID = "@anatest2-yop2.tchap.incubateur.net:dev02.tchap.incubateur.net"
+        let result = viewModel.convertMatrixIDToTchapEmail(matrixID)
+        
+        #expect(result == "anatest2@yop2.tchap.incubateur.net")
+    }
+    
+    @Test("Convert Matrix ID with multiple dashes returns nil")
+    func convertMatrixIDToTchapEmailMultipleDashes() async {
+        await setupViewModel()
+        
+        // Case 1: Username contains dash
+        let matrixID1 = "@anat-test2-yop2.tchap.incubateur.net:dev02.tchap.incubateur.net"
+        let result1 = viewModel.convertMatrixIDToTchapEmail(matrixID1)
+        #expect(result1 == nil, "Should return nil when there are multiple dashes (ambiguous)")
+        
+        // Case 2: Domain contains dash
+        let matrixID2 = "@anatest2-yop-2.tchap.incubateur.net:dev02.tchap.incubateur.net"
+        let result2 = viewModel.convertMatrixIDToTchapEmail(matrixID2)
+        #expect(result2 == nil, "Should return nil when domain contains dash")
+        
+        // Case 3: Username and Domain contains dash
+        let matrixID3 = "@ana-test2-yop-2.tchap.incubateur.net:dev02.tchap.incubateur.net"
+        let result3 = viewModel.convertMatrixIDToTchapEmail(matrixID3)
+        #expect(result3 == nil, "Should return nil when username and domain contains dash")
+    }
+    
+    @Test("Convert Matrix ID with no dash returns nil")
+    func convertMatrixIDToTchapEmailNoDash() async {
+        await setupViewModel()
+        
+        let matrixID = "@anatest2yop2.tchap.incubateur.net:dev02.tchap.incubateur.net"
+        let result = viewModel.convertMatrixIDToTchapEmail(matrixID)
+        
+        #expect(result == nil, "Should return nil when there's no dash")
+    }
+    
+    @Test("Convert Matrix ID with no domain returns nil")
+    func convertMatrixIDToTchapEmailNoDomain() async {
+        await setupViewModel()
+        
+        let matrixID = "@anatest2yop2-tchap:dev02.tchap.incubateur.net"
+        let result = viewModel.convertMatrixIDToTchapEmail(matrixID)
+        
+        #expect(result == nil, "Should return nil when there's no dash")
+    }
 }
 
 extension AuthenticationStartScreenViewModelAction {


### PR DESCRIPTION
issue : #365 

Contexte pour reproduire : être connecté dans Tchap classique mais déconnecté de la webview MAS 
L'email se pré-remplit mais au mauvais format 


